### PR TITLE
Instance sa default parameterization / Using Latest Debian version

### DIFF
--- a/gcloud/instance.jinja
+++ b/gcloud/instance.jinja
@@ -3,7 +3,7 @@
 {% set preemptible = properties['preemptible'] or true %} # preemptible: 'false' in config to override (premptible: false will result in the or true being used)
 {% set zone = properties['zone'] or 'us-central1-a' %}
 {% set network = properties['network'] or 'global/networks/default' %}
-{% set serviceAccountEmail = properties['serviceAccountEmail'] or env['project_number']-compute@developer.gserviceaccount.com %}
+{% set serviceAccountEmail = properties['serviceAccountEmail'] or env['project_number']'-compute@developer.gserviceaccount.com' %}
 
 resources:
 - name: {{ properties['name'] }}

--- a/gcloud/instance.jinja
+++ b/gcloud/instance.jinja
@@ -1,5 +1,5 @@
 {% set machineType = properties['machineType'] or 'f1-micro' %}
-{% set sourceImage = properties['sourceImage'] or 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-10-buster-v20211028' %}
+{% set sourceImage = properties['sourceImage'] or 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-10-buster' %}
 {% set preemptible = properties['preemptible'] or true %} # preemptible: 'false' in config to override (premptible: false will result in the or true being used)
 {% set zone = properties['zone'] or 'us-central1-a' %}
 {% set network = properties['network'] or 'global/networks/default' %}

--- a/gcloud/instance.jinja
+++ b/gcloud/instance.jinja
@@ -3,7 +3,7 @@
 {% set preemptible = properties['preemptible'] or true %} # preemptible: 'false' in config to override (premptible: false will result in the or true being used)
 {% set zone = properties['zone'] or 'us-central1-a' %}
 {% set network = properties['network'] or 'global/networks/default' %}
-{% set serviceAccountEmail = properties['serviceAccountEmail'] or env['project_number']'-compute@developer.gserviceaccount.com' %}
+{% set serviceAccountEmail = properties['serviceAccountEmail'] or env['project_number'] ~ '-compute@developer.gserviceaccount.com' %}
 
 resources:
 - name: {{ properties['name'] }}

--- a/gcloud/instance.jinja
+++ b/gcloud/instance.jinja
@@ -3,6 +3,7 @@
 {% set preemptible = properties['preemptible'] or true %} # preemptible: 'false' in config to override (premptible: false will result in the or true being used)
 {% set zone = properties['zone'] or 'us-central1-a' %}
 {% set network = properties['network'] or 'global/networks/default' %}
+{% set serviceAccountEmail = properties['serviceAccountEmail'] or env['project_number']-compute@developer.gserviceaccount.com %}
 
 resources:
 - name: {{ properties['name'] }}
@@ -37,7 +38,7 @@ resources:
     scheduling: 
       preemptible: {{ preemptible }}
     serviceAccounts:
-      - email: {{ env['project_number'] }}-compute@developer.gserviceaccount.com
+      - email: {{ serviceAccountEmail }}
         scopes: {{ properties['scopes'] }}
   
 outputs:


### PR DESCRIPTION
@Bsingh-CA @danielwood-ca I have been playing with this change locally and believe it is good to roll out to the main brach.  It will prevent having to periodically update the debian image by using the latest version.  I don't think updating the version has ever broken anything, is that correct?  In this case we can have it automatically use the latest version instead of us manually updating when the existing one gets deprecated.  debian buster will be maintained to 2024.